### PR TITLE
Ghostscript: add appleraster to the driver list

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -328,7 +328,7 @@ parts:
       - --prefix=/
       - --without-x
       - --disable-gtk
-      - --with-drivers=pdfwrite,ps2write,cups,pwgraster,pxlmono,pxlcolor
+      - --with-drivers=pdfwrite,ps2write,cups,pwgraster,pxlmono,pxlcolor,appleraster
       - --enable-cups
       - --enable-freetype
       - --without-tesseract


### PR DESCRIPTION
cups-filter, since 056d2b5 ("libcupsfilters: For ghostscript() require
GS 9.56.0"), seems to unconditionally require GS's "appleraster" driver.
As it seems not to be built with the current driver list, add it to the
driver list.

This fixes printing to AirPrint-enabled printers - or at least, it fixes
printing to my Brother MFC J430W.

-----

BTW, I noticed that there's a few drivers mentioned in cups-filter's [ghostscript.c](https://github.com/OpenPrinting/cups-filters/blob/master/cupsfilters/ghostscript.c) that isn't in this driver list. I'm not sure how GS's build system work, so maybe it's in there. Also, maybe it's not needed in the context of cups-snap. So, maybe take a look?