### PR TITLE
Remove cupsManualCopies in proxy config

### DIFF
--- a/cups-proxyd/cups-proxyd.c
+++ b/cups-proxyd/cups-proxyd.c
@@ -768,6 +768,11 @@ clone_system_queue_to_proxy (cups_dest_t *dest)
 	    ap_remote_queue_id_line_inserted = 1;
 	    cupsFilePrintf(out, "*APRemoteQueueID: \"\"\n");
 	  }
+
+	  /* System's CUPS will handle copies */
+	  if (!strncasecmp(line, "*cupsManualCopies: true", 23))
+		continue;
+
 	  /* Simply write out the line as we read it */
 	  cupsFilePrintf(out, "%s\n", line);
 	}


### PR DESCRIPTION
Fixes issue with duplicate copies when cups-snap is operating as proxy on printers with cupsManualCopies set to true in original ppd. Issue: #25 