### PR TITLE
Fix malformed shell test in run-cupsd cups-proxyd shutdown check

### DIFF
--- a/scripts/run-cupsd
+++ b/scripts/run-cupsd
@@ -308,7 +308,7 @@ wait $CUPS_PID
 # Remove CUPS PID file as process is done
 rm -f $SNAP_DATA/var/run/cupsd.pid
 
-if [ -r $SNAP_DATA/var/run/cups-proxyd.pid && kill -0 "${PROXYD_PID}" 2>/dev/null]; then
+if [ -r "$SNAP_DATA/var/run/cups-proxyd.pid" ] && kill -0 "${PROXYD_PID}" 2>/dev/null; then
     # Kill cups-proxyd if not already terminated by stop-cupsd
     kill -KILL $PROXYD_PID
 fi


### PR DESCRIPTION
## Summary

The cups-proxyd shutdown check in `scripts/run-cupsd` is not a valid shell test:

```sh
  if [ -r $SNAP_DATA/var/run/cups-proxyd.pid && kill -0 "${PROXYD_PID}" 2>/dev/null]; then
```
  Two problems in that one line:
  - && is used inside a single [ ... ] — [ is the test command, so it can't join two conditions; it runs without a closing ].
  - The ] is glued to the redirect (2>/dev/null]), so it's passed as a stray argument to kill rather than closing the test.

As written, test errors on the missing ] and kill gets a bogus ] argument, so the intended "kill cups-proxyd only if its PID file is readable and the process is still alive" never works correctly.

### Fix
Split it into a proper test joined by && to the kill -0 command, with the redirect placed correctly:
```sh
if [ -r "$SNAP_DATA/var/run/cups-proxyd.pid" ] && kill -0 "${PROXYD_PID}" 2>/dev/null; then
```
This path only runs at proxy-mode shutdown. One-line change, no behavioral change in stand-alone mode.
