### PR TITLE
Add CI tests for the CUPS Snap in stand-alone, proxy and parallel modes across architectures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,21 +41,20 @@ jobs:
         with:
           path: .
 
-      - name: Install built snap (smoke test setup)
+      - name: Install built snap
         run: |
           set -e
           SNAP_FILE="${{ steps.snapcraft.outputs.snap }}"
           echo "Installing snap: ${SNAP_FILE}"
           sudo snap install --dangerous "${SNAP_FILE}"
+          snap list | grep "^cups " || (echo "CUPS snap not found in snap list"; exit 1)
 
-      - name: Run smoke tests
+      - name: Sandbox integration test (full print-through)
         run: |
           set -e
-          echo "Checking snap list..."
-          snap list | grep "^cups " || (echo "CUPS snap not found in snap list"; exit 1)
-          
-          echo "Testing ghostscript binary..."
-          snap run cups.gs -h || true
+          # Drives a real driverless print job through the snap's bundled
+          # cupsd + filter chain.  Needs root for `snap connect`.
+          sudo sh tests/sandbox-test.sh
 
       - name: Cleanup - Remove installed snap
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,9 @@ permissions:
   pull-requests: write # Added this so the bot can post the PR comment
 
 jobs:
-  # Job 1: Native builds for amd64 and arm64
+  # Job 1: Build the snap once per native architecture and publish it as an
+  # artifact.  The per-mode tests download it, so the (slow) snap build runs
+  # once per arch instead of once per mode.
   build-native:
     name: Build Native (${{ matrix.arch }})
     runs-on: ${{ matrix.runs-on }}
@@ -41,46 +43,53 @@ jobs:
         with:
           path: .
 
-      - name: Install built snap
-        run: |
-          set -e
-          SNAP_FILE="${{ steps.snapcraft.outputs.snap }}"
-          echo "Installing snap: ${SNAP_FILE}"
-          sudo snap install --dangerous "${SNAP_FILE}"
-          snap list | grep "^cups " || (echo "CUPS snap not found in snap list"; exit 1)
-
-      - name: Set up Avahi for the driverless test
-        run: |
-          set -e
-          # ippeveprinter advertises the virtual printer over DNS-SD and aborts
-          # (avahi assertion) if no Avahi daemon is reachable, so make sure one
-          # is running on the runner before the print-through.
-          sudo apt-get update
-          sudo apt-get install -y avahi-daemon avahi-utils dbus
-          sudo systemctl start dbus 2>/dev/null || sudo service dbus start || true
-          sudo systemctl start avahi-daemon 2>/dev/null || sudo service avahi-daemon start || true
-          sleep 2
-          systemctl is-active avahi-daemon || true
-
-      - name: Sandbox integration test (full print-through)
-        run: |
-          set -e
-          # Drives a real driverless print job through the snap's bundled
-          # cupsd + filter chain.  Needs root for `snap connect`.
-          sudo sh tests/sandbox-test.sh
-
-      - name: Cleanup - Remove installed snap
-        if: always()
-        run: |
-          echo "Removing CUPS snap..."
-          sudo snap remove cups || true
-
       - name: Upload CUPS snap artifact
         uses: actions/upload-artifact@v4
         with:
           name: cups-snap-${{ matrix.arch }}
           path: ./*.snap
           if-no-files-found: error
+
+  # Job 2: Test each native snap in all three run-cupsd operating modes
+  # (stand-alone, proxy, parallel).  Each (arch, mode) runs in its own fresh
+  # job so the modes can't interfere with each other (e.g. who owns port 631)
+  # and a failure points at exactly one mode.
+  test-native:
+    name: Test ${{ matrix.arch }} (${{ matrix.mode }})
+    needs: build-native
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { arch: amd64, runs-on: ubuntu-latest,    mode: standalone }
+          - { arch: amd64, runs-on: ubuntu-latest,    mode: proxy }
+          - { arch: amd64, runs-on: ubuntu-latest,    mode: parallel }
+          - { arch: arm64, runs-on: ubuntu-24.04-arm, mode: standalone }
+          - { arch: arm64, runs-on: ubuntu-24.04-arm, mode: proxy }
+          - { arch: arm64, runs-on: ubuntu-24.04-arm, mode: parallel }
+    steps:
+      - name: Checkout cups-snap sources
+        uses: actions/checkout@v4
+
+      - name: Download the built snap
+        uses: actions/download-artifact@v4
+        with:
+          name: cups-snap-${{ matrix.arch }}
+          path: snap-artifact
+
+      - name: Sandbox integration test (${{ matrix.mode }} mode)
+        run: |
+          set -e
+          SNAP_FILE="$(ls snap-artifact/*.snap | head -1)"
+          echo "Testing ${{ matrix.mode }} mode with ${SNAP_FILE}"
+          sudo sh tests/sandbox-test.sh "${{ matrix.mode }}" "${SNAP_FILE}"
+
+      - name: Cleanup - Remove installed snap
+        if: always()
+        run: |
+          echo "Removing CUPS snap..."
+          sudo snap remove cups || true
 
   # Job 2: Remote build via Launchpad for armhf
   # Job 2: Remote build via Launchpad for armhf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: CUPS Snap CI - Unified Build Pipeline
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
     branches:
-      - master
+      - '**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,19 @@ jobs:
           sudo snap install --dangerous "${SNAP_FILE}"
           snap list | grep "^cups " || (echo "CUPS snap not found in snap list"; exit 1)
 
+      - name: Set up Avahi for the driverless test
+        run: |
+          set -e
+          # ippeveprinter advertises the virtual printer over DNS-SD and aborts
+          # (avahi assertion) if no Avahi daemon is reachable, so make sure one
+          # is running on the runner before the print-through.
+          sudo apt-get update
+          sudo apt-get install -y avahi-daemon avahi-utils dbus
+          sudo systemctl start dbus 2>/dev/null || sudo service dbus start || true
+          sudo systemctl start avahi-daemon 2>/dev/null || sudo service avahi-daemon start || true
+          sleep 2
+          systemctl is-active avahi-daemon || true
+
       - name: Sandbox integration test (full print-through)
         run: |
           set -e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,18 @@ jobs:
             exit $EXIT_CODE
           fi
 
+      - name: Smoke test (armhf, emulated)
+        if: steps.check-secrets.outputs.available == 'true'
+        run: |
+          set -e
+          # snapd cannot run under emulation, so we unpack the Launchpad-built
+          # armhf snap and run its bundled binaries through qemu-user instead of
+          # the full daemon-level print-through (that runs on the native legs).
+          sudo apt-get update
+          sudo apt-get install -y qemu-user-static squashfs-tools
+          SNAP_FILE="$(ls ./*.snap | head -1)"
+          sh tests/smoke-unpacked.sh "${SNAP_FILE}" qemu-arm-static
+
       - name: Upload CUPS snap artifact
         if: steps.check-secrets.outputs.available == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,15 +133,24 @@ jobs:
           OUTPUT=$(snapcraft remote-build --launchpad-accept-public-upload --build-for=armhf 2>&1)
           EXIT_CODE=$?
           set -e # Re-enable auto-exit
-          
-          if [ $EXIT_CODE -ne 0 ]; then
-            echo "$OUTPUT" # Print the full log for debugging
+          echo "$OUTPUT" # Print the full log for debugging
+
+          if ls ./*.snap >/dev/null 2>&1; then
+            # The build artifact is present.  snapcraft remote-build sometimes
+            # still exits non-zero because of a transient glitch while fetching
+            # the build *logs* from Launchpad AFTER a successful build+download
+            # (e.g. "RemoteDisconnected ... fetching build logs"); that must not
+            # fail the job when the snap itself was produced.
+            if [ $EXIT_CODE -ne 0 ]; then
+              echo "::warning::snapcraft remote-build exited ${EXIT_CODE}, but the armhf snap was produced; treating as success."
+            fi
+          else
             if echo "$OUTPUT" | grep -iqE "macaroon|unauthorized|authentication|login|credentials"; then
               echo "::error::Secrets are invalid or expired. Launchpad authentication failed."
             else
-              echo "::error::Launchpad build failed due to a code compilation error or infrastructure issue."
+              echo "::error::Launchpad build failed (no snap artifact produced)."
             fi
-            exit $EXIT_CODE
+            exit "${EXIT_CODE:-1}"
           fi
 
       - name: Smoke test (armhf, emulated)

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -3,10 +3,10 @@ name: cppcheck
 on:
   push:
     branches:
-      - master
+      - '**'
   pull_request:
     branches:
-      - master
+      - '**'
   workflow_dispatch:
 jobs:
   cppcheck:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [ master ]
+    branches: [ '**' ]
   pull_request:
-    branches: [ master ]
+    branches: [ '**' ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-riscv-edge.yml
+++ b/.github/workflows/test-riscv-edge.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Checkout cups-snap sources
+        uses: actions/checkout@v4
+
       - name: Query Snap Store API for CUPS
         id: snap-info
         run: |
@@ -48,18 +51,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user-static squashfs-tools
 
-      - name: Unpack and Smoke Test
+      - name: Unpack and smoke test (riscv64, emulated)
         if: steps.snap-info.outputs.available == 'true'
         run: |
-          # Because GitHub runners cannot easily run a full RISC-V system daemon (snapd), 
-          # the standard CI trick is to unpack the snap and test the binaries directly using QEMU.
-          
-          echo "Unpacking snap..."
-          unsquashfs -d unpacked_snap cups_riscv64.snap
-          
-          echo "Testing Ghostscript binary via RISC-V emulation..."
-          # Note: We kept '|| true' here based on your earlier smoke tests so it doesn't hard-crash if gs acts weird in emulation.
-          qemu-riscv64-static ./unpacked_snap/usr/bin/gs -h || true
-          
-          echo "::notice::The RISC-V Snap (Version: ${{ steps.snap-info.outputs.version }}) was successfully downloaded from Edge and smoke tested!"
+          set -e
+          # snapd cannot run a full RISC-V system daemon under emulation, so we
+          # unpack the snap and run its bundled binaries through qemu-user.  This
+          # uses the same helper as the armhf leg in build.yml.
+          sh tests/smoke-unpacked.sh cups_riscv64.snap qemu-riscv64-static
+          echo "::notice::The RISC-V Snap (Version: ${{ steps.snap-info.outputs.version }}) was downloaded from Edge and smoke tested!"
 

--- a/tests/ci-generic.ppd
+++ b/tests/ci-generic.ppd
@@ -1,0 +1,44 @@
+*PPD-Adobe: "4.3"
+*% Minimal generic PostScript PPD used by the cups-snap CI proxy-mode test.
+*% A raw queue cannot be cloned by cups-proxyd ("Unable to load PPD ... Bad
+*% Request"), so the proxy test creates the host queue the classic way with
+*% this PPD; cups-proxyd then mirrors it into the snapped CUPS.
+*FormatVersion: "4.3"
+*FileVersion: "1.0"
+*LanguageVersion: English
+*LanguageEncoding: ISOLatin1
+*PCFileName: "CIGENERIC.PPD"
+*Manufacturer: "Generic"
+*Product: "(Generic PostScript Printer)"
+*ModelName: "Generic PostScript Printer"
+*ShortNickName: "Generic PostScript Printer"
+*NickName: "Generic PostScript Printer"
+*PSVersion: "(3010.000) 0"
+*LanguageLevel: "3"
+*ColorDevice: False
+*DefaultColorSpace: Gray
+*FileSystem: False
+*Throughput: "1"
+*LandscapeOrientation: Plus90
+*TTRasterizer: Type42
+*cupsVersion: 2.4
+*cupsModelNumber: 0
+*cupsManualCopies: False
+*OpenUI *PageSize/Media Size: PickOne
+*OrderDependency: 10 AnySetup *PageSize
+*DefaultPageSize: Letter
+*PageSize Letter/US Letter: "<</PageSize[612 792]>>setpagedevice"
+*PageSize A4/A4: "<</PageSize[595 842]>>setpagedevice"
+*CloseUI: *PageSize
+*OpenUI *PageRegion/Media Size: PickOne
+*OrderDependency: 10 AnySetup *PageRegion
+*DefaultPageRegion: Letter
+*PageRegion Letter/US Letter: "<</PageSize[612 792]>>setpagedevice"
+*PageRegion A4/A4: "<</PageSize[595 842]>>setpagedevice"
+*CloseUI: *PageRegion
+*DefaultImageableArea: Letter
+*ImageableArea Letter/US Letter: "0 0 612 792"
+*ImageableArea A4/A4: "0 0 595 842"
+*DefaultPaperDimension: Letter
+*PaperDimension Letter/US Letter: "612 792"
+*PaperDimension A4/A4: "595 842"

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -1,0 +1,156 @@
+#!/bin/sh
+#
+# tests/sandbox-test.sh
+#
+# Full "print-through" integration test for the CUPS Snap, run inside the
+# snap's own confined environment.  A Snap is a self-contained, read-only,
+# confined filesystem bundling its whole printing stack (CUPS, libcupsfilters,
+# libppd, cups-filters, Ghostscript, ...), so the multi-CUPS build matrix used
+# by the Autotools repositories does not apply here.  Instead we install the
+# built snap, let its bundled cupsd run, set up a virtual IPP-Everywhere
+# printer with the bundled ippeveprinter, and push a real job through the
+# bundled filter chain -- exercising the actual stack end to end.
+#
+# This requires a working snapd, so it only runs on the native runners
+# (amd64/arm64).  The emulated architectures (armhf/riscv64), where snapd
+# cannot run under CI, use the non-daemon tests/smoke-unpacked.sh instead.
+#
+# The CI invokes this as root:  sudo sh tests/sandbox-test.sh
+# It assumes the "cups" snap is already installed (the build job installs the
+# freshly built .snap with `snap install --dangerous`).  Snap removal is left
+# to the workflow's cleanup step; this script cleans up only what it creates.
+
+set -eu
+
+QUEUE="ci-everywhere"
+PRINTER_PORT=8631
+PRINTER_URI="ipp://localhost:${PRINTER_PORT}/ipp/print"
+IPPEVE_LOG="$(mktemp)"
+IPPEVE_PID=""
+
+log()  { echo "sandbox-test: $*"; }
+group(){ echo "::group::$*"; }
+endgr(){ echo "::endgroup::"; }
+
+dump_diagnostics() {
+	group "diagnostics"
+	echo "--- snap services ---";    snap services cups            2>&1 || true
+	echo "--- snap connections ---"; snap connections cups         2>&1 || true
+	echo "--- snap logs ---";        snap logs cups -n 200         2>&1 || true
+	echo "--- lpstat -t ---";        cups.lpstat -t                2>&1 || true
+	echo "--- cupsd error_log ---"
+	# ErrorLog lives under $SNAP_DATA (see scripts/run-cupsd); current -> revision.
+	tail -n 200 /var/snap/cups/current/var/log/error_log 2>/dev/null || true
+	echo "--- ippeveprinter log ---"; tail -n 200 "$IPPEVE_LOG"   2>/dev/null || true
+	endgr
+}
+
+cleanup() {
+	cups.cancel -a "$QUEUE"   >/dev/null 2>&1 || true
+	cups.lpadmin -x "$QUEUE"  >/dev/null 2>&1 || true
+	[ -n "$IPPEVE_PID" ] && kill "$IPPEVE_PID" >/dev/null 2>&1 || true
+	pkill -f "ippeveprinter" >/dev/null 2>&1 || true
+	rm -f "$IPPEVE_LOG"
+}
+
+# Diagnose on failure, always clean up.
+trap 'rc=$?; [ "$rc" -ne 0 ] && { log "FAILED (exit $rc)"; dump_diagnostics; }; cleanup; exit $rc' EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Sanity: the snap is installed.
+# ---------------------------------------------------------------------------
+snap list cups >/dev/null 2>&1 || { log "cups snap is not installed"; exit 1; }
+log "cups snap installed:"; snap list cups
+
+# ---------------------------------------------------------------------------
+# 2. Connect the interfaces the test needs.  network/network-bind auto-connect;
+#    the rest are best-effort (absent slots on a bare runner are harmless, the
+#    stand-alone cupsd does not need them).
+# ---------------------------------------------------------------------------
+for plug in avahi-control raw-usb etc-cups cups-control cups-host; do
+	snap connect "cups:$plug" >/dev/null 2>&1 || true
+done
+
+# ---------------------------------------------------------------------------
+# 3. Wait for the bundled cupsd (snap daemon) to come up.
+# ---------------------------------------------------------------------------
+log "waiting for the snap's cupsd to accept connections..."
+ready=0
+i=0
+while [ "$i" -lt 60 ]; do
+	if cups.lpstat -r 2>/dev/null | grep -q 'scheduler is running'; then
+		ready=1; break
+	fi
+	i=$((i + 1)); sleep 1
+done
+[ "$ready" = 1 ] || { log "cupsd did not become ready in time"; exit 1; }
+log "cupsd is running"
+
+# ---------------------------------------------------------------------------
+# 4. Start a virtual IPP-Everywhere printer (bundled ippeveprinter).  We point
+#    the queue at it by explicit URI, so DNS-SD/Avahi is not required.
+# ---------------------------------------------------------------------------
+log "starting ippeveprinter on port ${PRINTER_PORT}..."
+cups.ippeveprinter -p "$PRINTER_PORT" "CI Everywhere Printer" >"$IPPEVE_LOG" 2>&1 &
+IPPEVE_PID=$!
+
+# ---------------------------------------------------------------------------
+# 5. Create a driverless ("everywhere") queue from that printer.  lpadmin has
+#    to reach the printer to fetch its IPP attributes, so retrying here also
+#    serves as the readiness wait for ippeveprinter.
+# ---------------------------------------------------------------------------
+log "creating everywhere queue '${QUEUE}' from ${PRINTER_URI}..."
+created=0
+i=0
+while [ "$i" -lt 30 ]; do
+	if kill -0 "$IPPEVE_PID" 2>/dev/null && \
+	   cups.lpadmin -p "$QUEUE" -v "$PRINTER_URI" -m everywhere -E >/dev/null 2>&1; then
+		created=1; break
+	fi
+	i=$((i + 1)); sleep 1
+done
+[ "$created" = 1 ] || { log "could not create the everywhere queue"; exit 1; }
+cups.lpstat -p "$QUEUE" || true
+cups.lpstat -v "$QUEUE" || true
+
+# ---------------------------------------------------------------------------
+# 6. Push a job through the bundled filter chain.  Printing from stdin avoids
+#    needing the "home" interface to read a file from disk.
+# ---------------------------------------------------------------------------
+log "submitting a print job..."
+jobout="$(printf 'CUPS Snap CI print-through test.\nThe bundled filter chain converted this text.\n' \
+	| cups.lp -d "$QUEUE" -t ci-print-through 2>&1)" || {
+		log "lp failed: $jobout"; exit 1; }
+echo "$jobout"
+jobid="$(printf '%s' "$jobout" | sed -n 's/.*request id is \([^ ]*\).*/\1/p')"
+[ -n "$jobid" ] || { log "could not determine the job id"; exit 1; }
+log "submitted job: $jobid"
+
+# ---------------------------------------------------------------------------
+# 7. Verify the job actually COMPLETED (an aborted/held job never appears in
+#    the completed list -- so this distinguishes success from a stuck queue).
+# ---------------------------------------------------------------------------
+log "waiting for the job to complete..."
+done_ok=0
+i=0
+while [ "$i" -lt 60 ]; do
+	if cups.lpstat -W completed -o "$QUEUE" 2>/dev/null | grep -qw "$jobid"; then
+		done_ok=1; break
+	fi
+	i=$((i + 1)); sleep 1
+done
+[ "$done_ok" = 1 ] || { log "job $jobid did not complete in time"; exit 1; }
+log "job $jobid completed"
+
+# ---------------------------------------------------------------------------
+# 8. Confirm the virtual printer actually received the document (the job really
+#    traversed the stack, it was not just discarded by the scheduler).
+# ---------------------------------------------------------------------------
+if grep -Eqi 'job|print|document' "$IPPEVE_LOG"; then
+	log "ippeveprinter received the job"
+else
+	log "WARNING: no job activity seen in the ippeveprinter log (printed below)"
+	cat "$IPPEVE_LOG" || true
+fi
+
+log "PASS: full print-through succeeded through the snap's bundled stack"

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -59,6 +59,8 @@ dump_diagnostics() {
 		echo "--- host lpstat -t ---"; lpstat -t           2>&1 || true
 		echo "--- host cupsd error_log ---"
 		tail -n 150 /var/log/cups/error_log 2>/dev/null || true
+		echo "--- cups-proxyd log ---"
+		tail -n 150 /var/snap/cups/current/var/log/cups-proxyd_log 2>/dev/null || true
 	fi
 	if [ "$MODE" = standalone ]; then
 		echo "--- ippeveprinter log ---"; tail -n 150 "$IPPEVE_LOG" 2>/dev/null || true
@@ -196,37 +198,46 @@ run_standalone() {
 # ---------------------------------------------------------------------------
 run_proxy() {
 	# Host CUPS present, no no-proxy marker -> snap runs as a proxy.  The queue
-	# lives on the HOST cupsd; the snap mirrors it and proxies snapped clients'
-	# jobs to it.
+	# lives on the HOST cupsd; the snap's cups-proxyd mirrors it into the snapped
+	# CUPS and the snapped client's job is proxied to the host.
 	install_host_cups
-	install_snap                       # detects host CUPS -> proxy mode
-	wait_scheduler "cups.lpstat"       # snap cupsd (on its domain socket)
+	# dbus lets the host CUPS deliver live add/remove notifications to
+	# cups-proxyd (belt and suspenders alongside its start-up sync below).
+	systemctl start dbus 2>/dev/null || service dbus start || true
 
-	# Create the queue on the host CUPS.
+	# Create the queue on the host CUPS *before* cups-proxyd starts, so its
+	# start-up "sync with current state" (see cups-proxyd.c) mirrors an already
+	# existing queue -- rather than relying on a live notification.
 	make_raw_queue "lpadmin" "lpstat"
 
-	# The snap's cups-proxyd should mirror the host queue into the snapped CUPS.
+	install_snap                       # snap detects host CUPS -> proxy mode
+	# cups-proxyd is spawned by run-cupsd, but at first install it started before
+	# the cups-host plug was connected (so it could not reach the host CUPS).
+	# Restart now that cups-host is connected and the host queue exists, so its
+	# start-up sync mirrors the queue.
+	log "restarting the snapped cupsd so cups-proxyd syncs the host queues..."
+	snap restart cups.cupsd
+	wait_scheduler "cups.lpstat"       # snap cupsd (on its domain socket)
+
+	# Require the host queue to be mirrored into the snapped CUPS (proxy:// device).
 	log "waiting for the host queue to be mirrored into the snapped CUPS..."
 	mirrored=0; i=0
-	while [ "$i" -lt 30 ]; do
+	while [ "$i" -lt 60 ]; do
 		if cups.lpstat -v "$QUEUE" 2>/dev/null | grep -q "$QUEUE"; then
 			mirrored=1; break
 		fi
 		i=$((i + 1)); sleep 1
 	done
+	[ "$mirrored" = 1 ] || { log "host queue was not mirrored into the snap by cups-proxyd"; return 1; }
+	log "queue mirrored into the snapped CUPS:"; cups.lpstat -v "$QUEUE" || true
 
-	if [ "$mirrored" = 1 ]; then
-		log "queue mirrored; printing via the snapped client (proxied to host)"
-		printf 'CUPS Snap CI (proxy) print-through test.\n' \
-			| cups.lp -d "$QUEUE" -t ci-job 2>&1 || { log "snapped lp failed"; return 1; }
-	else
-		log "WARNING: queue not mirrored into the snap; printing via the host client"
-		printf 'CUPS Snap CI (proxy) print-through test.\n' \
-			| lp -d "$QUEUE" -t ci-job 2>&1 || { log "host lp failed"; return 1; }
-	fi
+	# Print via the SNAPPED client; the job must traverse the proxy to the host.
+	log "printing via the snapped client (job is proxied to the host CUPS)..."
+	printf 'CUPS Snap CI (proxy) print-through test.\n' \
+		| cups.lp -d "$QUEUE" -t ci-job 2>&1 || { log "snapped lp failed"; return 1; }
 
-	# Either way the job must complete on the HOST queue.
-	log "waiting for the job to complete on the host CUPS..."
+	# The job must complete on the HOST queue (proves the proxy path end to end).
+	log "waiting for the proxied job to complete on the host CUPS..."
 	done_ok=0; i=0
 	while [ "$i" -lt 60 ]; do
 		if lpstat -W completed -o "$QUEUE" 2>/dev/null | grep -q "$QUEUE"; then
@@ -234,8 +245,8 @@ run_proxy() {
 		fi
 		i=$((i + 1)); sleep 1
 	done
-	[ "$done_ok" = 1 ] || { log "job did not complete on the host CUPS"; return 1; }
-	log "job completed on the host CUPS (proxy path)"
+	[ "$done_ok" = 1 ] || { log "proxied job did not complete on the host CUPS"; return 1; }
+	log "proxied job completed on the host CUPS (proxy path verified)"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -83,12 +83,14 @@ cleanup() {
 
 trap 'rc=$?; [ "$rc" -ne 0 ] && { log "FAILED (exit $rc)"; dump_diagnostics; }; cleanup; exit $rc' EXIT
 
-# wait_scheduler <lpstat-command> -- poll until "scheduler is running".
+# wait_scheduler <lpstat-command> -- poll until the scheduler is reachable.
+# Use the exit code of `lpstat -r` (0 when the scheduler is running), not its
+# printed message, which may change in future CUPS versions.
 wait_scheduler() {
 	cmd="$1"
 	i=0
 	while [ "$i" -lt 60 ]; do
-		if $cmd -r 2>/dev/null | grep -q 'scheduler is running'; then
+		if $cmd -r >/dev/null 2>&1; then
 			return 0
 		fi
 		i=$((i + 1)); sleep 1

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -46,6 +46,14 @@ IPPEVE_NAME="CITestPrinter"
 IPPEVE_LOG="$(mktemp)"
 IPPEVE_PID=""
 
+# Minimal "network printer": nc captures the AppSocket/JetDirect data the queue
+# sends on this port into PRINT_OUTPUT.  This replaces the file: backend, which
+# newer CUPS (2.4.x onwards) no longer provides.
+SOCKET_PORT=9100
+PRINTER_URI="socket://localhost:${SOCKET_PORT}/"
+PRINT_OUTPUT="$(mktemp)"
+NC_PID=""
+
 export DEBIAN_FRONTEND=noninteractive
 
 log()  { echo "sandbox-test[$MODE]: $*"; }
@@ -74,11 +82,13 @@ dump_diagnostics() {
 cleanup() {
 	[ -n "$IPPEVE_PID" ] && kill "$IPPEVE_PID" >/dev/null 2>&1 || true
 	pkill -f ippeveprinter >/dev/null 2>&1 || true
+	[ -n "$NC_PID" ] && kill "$NC_PID" >/dev/null 2>&1 || true
+	pkill -f "nc -l -k $SOCKET_PORT" >/dev/null 2>&1 || true
 	cups.cancel -a "$QUEUE"  >/dev/null 2>&1 || true
 	cups.lpadmin -x "$QUEUE" >/dev/null 2>&1 || true
 	cancel -a "$QUEUE"       >/dev/null 2>&1 || true
 	lpadmin -x "$QUEUE"      >/dev/null 2>&1 || true
-	rm -f "$IPPEVE_LOG"
+	rm -f "$IPPEVE_LOG" "$PRINT_OUTPUT"
 }
 
 trap 'rc=$?; [ "$rc" -ne 0 ] && { log "FAILED (exit $rc)"; dump_diagnostics; }; cleanup; exit $rc' EXIT
@@ -126,14 +136,42 @@ install_snap() {
 	done
 }
 
+# start_socket_printer -- a one-line network printer: accept the (filtered) job
+# data on SOCKET_PORT with nc and save it to PRINT_OUTPUT.  Gives the test a real,
+# hardware-free print sink plus a verifiable artifact, and avoids the file:
+# backend (gone in newer CUPS) entirely.
+start_socket_printer() {
+	command -v nc >/dev/null 2>&1 || apt-get install -y netcat-openbsd >/dev/null
+	log "starting socket printer on port $SOCKET_PORT (nc)..."
+	nc -l -k "$SOCKET_PORT" > "$PRINT_OUTPUT" 2>/dev/null &
+	NC_PID=$!
+	i=0
+	while [ "$i" -lt 30 ]; do
+		ss -ltn 2>/dev/null | grep -q ":$SOCKET_PORT" && return 0
+		kill -0 "$NC_PID" 2>/dev/null || { log "socket printer (nc) exited at startup"; return 1; }
+		i=$((i + 1)); sleep 1
+	done
+	log "socket printer did not start listening in time"
+	return 1
+}
+
+# verify_output -- confirm the socket printer actually received print data.
+verify_output() {
+	if [ -s "$PRINT_OUTPUT" ]; then
+		log "socket printer captured $(wc -c < "$PRINT_OUTPUT") bytes of print data"
+	else
+		log "WARNING: socket printer captured no data"
+	fi
+}
+
 # make_raw_queue <lpadmin-cmd> <lpstat-cmd> -- create a classic raw queue on the
-# file:/dev/null device (no ippeveprinter, so no DNS-SD queue leaking onto other
-# CUPS instances).  Raw is enough to validate that a job flows through the chosen
+# socket printer (no ippeveprinter, so no DNS-SD queue leaking onto other CUPS
+# instances).  Raw is enough to validate that a job flows through the chosen
 # cupsd in the chosen mode.
 make_raw_queue() {
 	lpadmin_cmd="$1"; lpstat_cmd="$2"
-	log "creating classic raw queue '$QUEUE' (file:/dev/null) via $lpadmin_cmd"
-	$lpadmin_cmd -p "$QUEUE" -v file:/dev/null -E
+	log "creating classic raw queue '$QUEUE' ($PRINTER_URI) via $lpadmin_cmd"
+	$lpadmin_cmd -p "$QUEUE" -v "$PRINTER_URI" -E
 	$lpstat_cmd -p "$QUEUE" || true
 	$lpstat_cmd -v "$QUEUE" || true
 }
@@ -209,15 +247,16 @@ run_proxy() {
 	# dbus lets the host CUPS deliver live add/remove notifications to
 	# cups-proxyd (belt and suspenders alongside its start-up sync below).
 	systemctl start dbus 2>/dev/null || service dbus start || true
+	start_socket_printer
 
 	# Create the queue on the host CUPS *before* cups-proxyd starts, so its
 	# start-up "sync with current state" (see cups-proxyd.c) mirrors an already
 	# existing queue -- rather than relying on a live notification.  Use a PPD
 	# (not a raw queue): cups-proxyd cannot clone raw queues ("Unable to load
 	# PPD ... Bad Request"), it needs the PPD to replicate the queue.
-	log "creating classic PPD queue '$QUEUE' on the host (file:/dev/null)..."
+	log "creating classic PPD queue '$QUEUE' on the host ($PRINTER_URI)..."
 	[ -f "$GENERIC_PPD" ] || { log "generic PPD not found: $GENERIC_PPD"; return 1; }
-	lpadmin -p "$QUEUE" -P "$GENERIC_PPD" -v file:/dev/null -E
+	lpadmin -p "$QUEUE" -P "$GENERIC_PPD" -v "$PRINTER_URI" -E
 	lpstat -p "$QUEUE" || true
 	lpstat -v "$QUEUE" || true
 
@@ -258,6 +297,7 @@ run_proxy() {
 	done
 	[ "$done_ok" = 1 ] || { log "proxied job did not complete on the host CUPS"; return 1; }
 	log "proxied job completed on the host CUPS (proxy path verified)"
+	verify_output
 }
 
 # ---------------------------------------------------------------------------
@@ -276,8 +316,10 @@ run_parallel() {
 	snap restart cups.cupsd
 	wait_scheduler "cups.lpstat"
 
+	start_socket_printer
 	make_raw_queue "cups.lpadmin" "cups.lpstat"
 	submit_and_verify "cups.lp" "cups.lpstat" || return 1
+	verify_output
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -1,164 +1,266 @@
 #!/bin/sh
 #
-# tests/sandbox-test.sh
+# tests/sandbox-test.sh <standalone|proxy|parallel> <snap-file>
 #
-# Full "print-through" integration test for the CUPS Snap, run inside the
-# snap's own confined environment.  A Snap is a self-contained, read-only,
-# confined filesystem bundling its whole printing stack (CUPS, libcupsfilters,
-# libppd, cups-filters, Ghostscript, ...), so the multi-CUPS build matrix used
-# by the Autotools repositories does not apply here.  Instead we install the
-# built snap, let its bundled cupsd run, set up a virtual IPP-Everywhere
-# printer with the bundled ippeveprinter, and push a real job through the
-# bundled filter chain -- exercising the actual stack end to end.
+# Integration test for the CUPS Snap, exercising the three operating modes its
+# run-cupsd selects between (see scripts/run-cupsd):
 #
-# This requires a working snapd, so it only runs on the native runners
-# (amd64/arm64).  The emulated architectures (armhf/riscv64), where snapd
-# cannot run under CI, use the non-daemon tests/smoke-unpacked.sh instead.
+#   standalone  no system CUPS on the host -> the snap's cupsd is THE system
+#               CUPS (port 631 + standard socket).  Queue on the snapped cupsd.
+#   proxy       a classic system CUPS is installed and there is no `no-proxy`
+#               marker -> the snap runs cups-proxyd and mirrors the host's
+#               queues; snapped clients' jobs are proxied to the host CUPS.
+#               Queue on the HOST cupsd.
+#   parallel    a classic system CUPS is installed AND the `no-proxy` marker
+#               exists -> the snap's cupsd runs independently on an alternative
+#               port/socket alongside the host's.  Queue on the snapped cupsd.
 #
-# The CI invokes this as root:  sudo sh tests/sandbox-test.sh
-# It assumes the "cups" snap is already installed (the build job installs the
-# freshly built .snap with `snap install --dangerous`).  Snap removal is left
-# to the workflow's cleanup step; this script cleans up only what it creates.
+# A Snap bundles its whole printing stack at pinned versions, so the multi-CUPS
+# build matrix used by the Autotools repos does not apply; what matters here is
+# that the snapped cupsd behaves correctly in each mode.  This runs only on the
+# native runners (snapd needs the host kernel); the emulated armhf/riscv64 legs
+# use tests/smoke-unpacked.sh instead.
+#
+# Invoked by CI as root:  sudo sh tests/sandbox-test.sh <mode> <snap-file>
+# Each mode runs in its own fresh job, so this script provisions whatever that
+# mode needs (host CUPS / no-proxy marker / Avahi) and installs the snap itself.
+#
+# NB: the snap's scripts/run-util execs the utilities via unquoted `$*`, so it
+# word-splits every argument -- no value passed to a cups.* command may contain
+# spaces.
 
 set -eu
 
-QUEUE="ci-everywhere"
-# NB: the snap's scripts/run-util execs the utilities via unquoted `$*`, so it
-# word-splits every argument -- no value passed to a cups.* command may contain
-# spaces.  Hence a single-token printer name here.
-PRINTER_NAME="CITestPrinter"
-PRINTER_PORT=8631
-PRINTER_URI="ipp://localhost:${PRINTER_PORT}/ipp/print"
+MODE="${1:?usage: sandbox-test.sh <standalone|proxy|parallel> <snap-file>}"
+SNAP_FILE="${2:?usage: sandbox-test.sh <standalone|proxy|parallel> <snap-file>}"
+
+QUEUE="ci-test"
+SNAP_FILESCONF="/var/snap/cups/common/etc/cups/cups-files.conf"
+HOST_FILESCONF="/etc/cups/cups-files.conf"
+NOPROXY_MARKER="/var/snap/cups/common/no-proxy"
+IPPEVE_PORT=8631
+IPPEVE_NAME="CITestPrinter"
 IPPEVE_LOG="$(mktemp)"
 IPPEVE_PID=""
 
-log()  { echo "sandbox-test: $*"; }
-group(){ echo "::group::$*"; }
-endgr(){ echo "::endgroup::"; }
+export DEBIAN_FRONTEND=noninteractive
+
+log()  { echo "sandbox-test[$MODE]: $*"; }
 
 dump_diagnostics() {
-	group "diagnostics"
-	echo "--- snap services ---";    snap services cups            2>&1 || true
-	echo "--- snap connections ---"; snap connections cups         2>&1 || true
-	echo "--- snap logs ---";        snap logs cups -n 200         2>&1 || true
-	echo "--- lpstat -t ---";        cups.lpstat -t                2>&1 || true
-	echo "--- cupsd error_log ---"
-	# ErrorLog lives under $SNAP_DATA (see scripts/run-cupsd); current -> revision.
-	tail -n 200 /var/snap/cups/current/var/log/error_log 2>/dev/null || true
-	echo "--- ippeveprinter log ---"; tail -n 200 "$IPPEVE_LOG"   2>/dev/null || true
-	endgr
+	echo "::group::diagnostics ($MODE)"
+	echo "--- snap services ---";    snap services cups    2>&1 || true
+	echo "--- snap connections ---"; snap connections cups 2>&1 || true
+	echo "--- snap logs ---";        snap logs cups -n 200 2>&1 || true
+	echo "--- snapped lpstat -t ---"; cups.lpstat -t       2>&1 || true
+	echo "--- snap cupsd error_log ---"
+	tail -n 150 /var/snap/cups/current/var/log/error_log 2>/dev/null || true
+	if [ "$MODE" != standalone ]; then
+		echo "--- host lpstat -t ---"; lpstat -t           2>&1 || true
+		echo "--- host cupsd error_log ---"
+		tail -n 150 /var/log/cups/error_log 2>/dev/null || true
+	fi
+	if [ "$MODE" = standalone ]; then
+		echo "--- ippeveprinter log ---"; tail -n 150 "$IPPEVE_LOG" 2>/dev/null || true
+	fi
+	echo "::endgroup::"
 }
 
 cleanup() {
-	cups.cancel -a "$QUEUE"   >/dev/null 2>&1 || true
-	cups.lpadmin -x "$QUEUE"  >/dev/null 2>&1 || true
 	[ -n "$IPPEVE_PID" ] && kill "$IPPEVE_PID" >/dev/null 2>&1 || true
-	pkill -f "ippeveprinter" >/dev/null 2>&1 || true
+	pkill -f ippeveprinter >/dev/null 2>&1 || true
+	cups.cancel -a "$QUEUE"  >/dev/null 2>&1 || true
+	cups.lpadmin -x "$QUEUE" >/dev/null 2>&1 || true
+	cancel -a "$QUEUE"       >/dev/null 2>&1 || true
+	lpadmin -x "$QUEUE"      >/dev/null 2>&1 || true
 	rm -f "$IPPEVE_LOG"
 }
 
-# Diagnose on failure, always clean up.
 trap 'rc=$?; [ "$rc" -ne 0 ] && { log "FAILED (exit $rc)"; dump_diagnostics; }; cleanup; exit $rc' EXIT
 
-# ---------------------------------------------------------------------------
-# 1. Sanity: the snap is installed.
-# ---------------------------------------------------------------------------
-snap list cups >/dev/null 2>&1 || { log "cups snap is not installed"; exit 1; }
-log "cups snap installed:"; snap list cups
+# wait_scheduler <lpstat-command> -- poll until "scheduler is running".
+wait_scheduler() {
+	cmd="$1"
+	i=0
+	while [ "$i" -lt 60 ]; do
+		if $cmd -r 2>/dev/null | grep -q 'scheduler is running'; then
+			return 0
+		fi
+		i=$((i + 1)); sleep 1
+	done
+	log "scheduler ($cmd) did not become ready in time"
+	return 1
+}
+
+# Enable the "file:" backend on a CUPS instance (off by default) so the test
+# queue can use file:/dev/null without any real hardware.
+enable_filedevice() {
+	conf="$1"
+	[ -f "$conf" ] || { log "cups-files.conf not found: $conf"; return 1; }
+	grep -q '^FileDevice Yes' "$conf" 2>/dev/null || echo 'FileDevice Yes' >> "$conf"
+}
+
+install_host_cups() {
+	log "installing the host (classic) CUPS..."
+	apt-get update -y >/dev/null
+	apt-get install -y cups cups-client >/dev/null
+	enable_filedevice "$HOST_FILESCONF"
+	systemctl restart cups 2>/dev/null || service cups restart || true
+	wait_scheduler "lpstat"
+}
+
+install_snap() {
+	log "installing the snap under test: $SNAP_FILE"
+	snap install --dangerous "$SNAP_FILE"
+	snap list cups
+	# network/network-bind auto-connect; the rest are best-effort.
+	for plug in avahi-control raw-usb etc-cups cups-control cups-host home; do
+		snap connect "cups:$plug" >/dev/null 2>&1 || true
+	done
+}
+
+# make_raw_queue <lpadmin-cmd> <lpstat-cmd> -- create a classic raw queue on the
+# file:/dev/null device (no ippeveprinter, so no DNS-SD queue leaking onto other
+# CUPS instances).  Raw is enough to validate that a job flows through the chosen
+# cupsd in the chosen mode.
+make_raw_queue() {
+	lpadmin_cmd="$1"; lpstat_cmd="$2"
+	log "creating classic raw queue '$QUEUE' (file:/dev/null) via $lpadmin_cmd"
+	$lpadmin_cmd -p "$QUEUE" -v file:/dev/null -E
+	$lpstat_cmd -p "$QUEUE" || true
+	$lpstat_cmd -v "$QUEUE" || true
+}
+
+# submit_and_verify <lp-cmd> <lpstat-cmd> -- print a stdin job and confirm it
+# reaches the completed list (an aborted/stuck job never appears there).
+submit_and_verify() {
+	lp_cmd="$1"; lpstat_cmd="$2"
+	log "submitting a print job via $lp_cmd..."
+	jobout="$(printf 'CUPS Snap CI (%s) print-through test.\n' "$MODE" \
+		| $lp_cmd -d "$QUEUE" -t ci-job 2>&1)" || { log "lp failed: $jobout"; return 1; }
+	echo "$jobout"
+
+	i=0
+	while [ "$i" -lt 60 ]; do
+		if $lpstat_cmd -W completed -o "$QUEUE" 2>/dev/null | grep -q "$QUEUE"; then
+			log "job completed on $lp_cmd's queue"
+			return 0
+		fi
+		i=$((i + 1)); sleep 1
+	done
+	log "job did not complete in time"
+	return 1
+}
 
 # ---------------------------------------------------------------------------
-# 2. Connect the interfaces the test needs.  network/network-bind auto-connect;
-#    the rest are best-effort (absent slots on a bare runner are harmless, the
-#    stand-alone cupsd does not need them).
-# ---------------------------------------------------------------------------
-for plug in avahi-control raw-usb etc-cups cups-control cups-host; do
-	snap connect "cups:$plug" >/dev/null 2>&1 || true
-done
+run_standalone() {
+	# Single CUPS instance -> ippeveprinter is safe (no other CUPS to pollute),
+	# so use it for a richer driverless print-through through the filter chain.
+	apt-get update -y >/dev/null
+	apt-get install -y avahi-daemon avahi-utils dbus >/dev/null
+	systemctl start dbus 2>/dev/null || service dbus start || true
+	systemctl start avahi-daemon 2>/dev/null || service avahi-daemon start || true
 
-# ---------------------------------------------------------------------------
-# 3. Wait for the bundled cupsd (snap daemon) to come up.
-# ---------------------------------------------------------------------------
-log "waiting for the snap's cupsd to accept connections..."
-ready=0
-i=0
-while [ "$i" -lt 60 ]; do
-	if cups.lpstat -r 2>/dev/null | grep -q 'scheduler is running'; then
-		ready=1; break
+	install_snap
+	wait_scheduler "cups.lpstat"
+
+	log "starting ippeveprinter '$IPPEVE_NAME' on port $IPPEVE_PORT..."
+	cups.ippeveprinter -p "$IPPEVE_PORT" "$IPPEVE_NAME" >"$IPPEVE_LOG" 2>&1 &
+	IPPEVE_PID=$!
+
+	log "creating everywhere queue '$QUEUE'..."
+	created=0; i=0
+	while [ "$i" -lt 30 ]; do
+		if ! kill -0 "$IPPEVE_PID" 2>/dev/null; then
+			log "ippeveprinter exited unexpectedly; its output was:"
+			cat "$IPPEVE_LOG" 2>/dev/null || true
+			return 1
+		fi
+		if cups.lpadmin -p "$QUEUE" -v "ipp://localhost:$IPPEVE_PORT/ipp/print" \
+				-m everywhere -E >/dev/null 2>&1; then
+			created=1; break
+		fi
+		i=$((i + 1)); sleep 1
+	done
+	[ "$created" = 1 ] || { log "could not create the everywhere queue"; return 1; }
+
+	submit_and_verify "cups.lp" "cups.lpstat" || return 1
+
+	if grep -Eqi 'job|print|document' "$IPPEVE_LOG"; then
+		log "ippeveprinter received the job"
+	else
+		log "WARNING: no job activity seen in the ippeveprinter log"
 	fi
-	i=$((i + 1)); sleep 1
-done
-[ "$ready" = 1 ] || { log "cupsd did not become ready in time"; exit 1; }
-log "cupsd is running"
+}
 
 # ---------------------------------------------------------------------------
-# 4. Start a virtual IPP-Everywhere printer (bundled ippeveprinter).  We point
-#    the queue at it by explicit URI, so DNS-SD/Avahi is not required.
-# ---------------------------------------------------------------------------
-log "starting ippeveprinter '${PRINTER_NAME}' on port ${PRINTER_PORT}..."
-cups.ippeveprinter -p "$PRINTER_PORT" "$PRINTER_NAME" >"$IPPEVE_LOG" 2>&1 &
-IPPEVE_PID=$!
+run_proxy() {
+	# Host CUPS present, no no-proxy marker -> snap runs as a proxy.  The queue
+	# lives on the HOST cupsd; the snap mirrors it and proxies snapped clients'
+	# jobs to it.
+	install_host_cups
+	install_snap                       # detects host CUPS -> proxy mode
+	wait_scheduler "cups.lpstat"       # snap cupsd (on its domain socket)
 
-# ---------------------------------------------------------------------------
-# 5. Create a driverless ("everywhere") queue from that printer.  lpadmin has
-#    to reach the printer to fetch its IPP attributes, so retrying here also
-#    serves as the readiness wait for ippeveprinter.
-# ---------------------------------------------------------------------------
-log "creating everywhere queue '${QUEUE}' from ${PRINTER_URI}..."
-created=0
-i=0
-while [ "$i" -lt 30 ]; do
-	if ! kill -0 "$IPPEVE_PID" 2>/dev/null; then
-		log "ippeveprinter exited unexpectedly; its output was:"
-		cat "$IPPEVE_LOG" 2>/dev/null || true
-		exit 1
+	# Create the queue on the host CUPS.
+	make_raw_queue "lpadmin" "lpstat"
+
+	# The snap's cups-proxyd should mirror the host queue into the snapped CUPS.
+	log "waiting for the host queue to be mirrored into the snapped CUPS..."
+	mirrored=0; i=0
+	while [ "$i" -lt 30 ]; do
+		if cups.lpstat -v "$QUEUE" 2>/dev/null | grep -q "$QUEUE"; then
+			mirrored=1; break
+		fi
+		i=$((i + 1)); sleep 1
+	done
+
+	if [ "$mirrored" = 1 ]; then
+		log "queue mirrored; printing via the snapped client (proxied to host)"
+		printf 'CUPS Snap CI (proxy) print-through test.\n' \
+			| cups.lp -d "$QUEUE" -t ci-job 2>&1 || { log "snapped lp failed"; return 1; }
+	else
+		log "WARNING: queue not mirrored into the snap; printing via the host client"
+		printf 'CUPS Snap CI (proxy) print-through test.\n' \
+			| lp -d "$QUEUE" -t ci-job 2>&1 || { log "host lp failed"; return 1; }
 	fi
-	if cups.lpadmin -p "$QUEUE" -v "$PRINTER_URI" -m everywhere -E >/dev/null 2>&1; then
-		created=1; break
-	fi
-	i=$((i + 1)); sleep 1
-done
-[ "$created" = 1 ] || { log "could not create the everywhere queue"; exit 1; }
-cups.lpstat -p "$QUEUE" || true
-cups.lpstat -v "$QUEUE" || true
+
+	# Either way the job must complete on the HOST queue.
+	log "waiting for the job to complete on the host CUPS..."
+	done_ok=0; i=0
+	while [ "$i" -lt 60 ]; do
+		if lpstat -W completed -o "$QUEUE" 2>/dev/null | grep -q "$QUEUE"; then
+			done_ok=1; break
+		fi
+		i=$((i + 1)); sleep 1
+	done
+	[ "$done_ok" = 1 ] || { log "job did not complete on the host CUPS"; return 1; }
+	log "job completed on the host CUPS (proxy path)"
+}
 
 # ---------------------------------------------------------------------------
-# 6. Push a job through the bundled filter chain.  Printing from stdin avoids
-#    needing the "home" interface to read a file from disk.
-# ---------------------------------------------------------------------------
-log "submitting a print job..."
-jobout="$(printf 'CUPS Snap CI print-through test.\nThe bundled filter chain converted this text.\n' \
-	| cups.lp -d "$QUEUE" -t ci-print-through 2>&1)" || {
-		log "lp failed: $jobout"; exit 1; }
-echo "$jobout"
-jobid="$(printf '%s' "$jobout" | sed -n 's/.*request id is \([^ ]*\).*/\1/p')"
-[ -n "$jobid" ] || { log "could not determine the job id"; exit 1; }
-log "submitted job: $jobid"
+run_parallel() {
+	# Host CUPS present AND no-proxy marker -> snap runs independently alongside
+	# the host CUPS on an alternative port/socket.  Queue on the snapped cupsd.
+	install_host_cups
+	install_snap                       # starts in proxy mode initially
+	mkdir -p "$(dirname "$NOPROXY_MARKER")"
+	touch "$NOPROXY_MARKER"            # force parallel (independent) mode
+	enable_filedevice "$SNAP_FILESCONF"
+	log "restarting the snapped cupsd into parallel mode..."
+	snap restart cups.cupsd
+	wait_scheduler "cups.lpstat"
+
+	make_raw_queue "cups.lpadmin" "cups.lpstat"
+	submit_and_verify "cups.lp" "cups.lpstat" || return 1
+}
 
 # ---------------------------------------------------------------------------
-# 7. Verify the job actually COMPLETED (an aborted/held job never appears in
-#    the completed list -- so this distinguishes success from a stuck queue).
-# ---------------------------------------------------------------------------
-log "waiting for the job to complete..."
-done_ok=0
-i=0
-while [ "$i" -lt 60 ]; do
-	if cups.lpstat -W completed -o "$QUEUE" 2>/dev/null | grep -qw "$jobid"; then
-		done_ok=1; break
-	fi
-	i=$((i + 1)); sleep 1
-done
-[ "$done_ok" = 1 ] || { log "job $jobid did not complete in time"; exit 1; }
-log "job $jobid completed"
+case "$MODE" in
+	standalone) run_standalone ;;
+	proxy)      run_proxy ;;
+	parallel)   run_parallel ;;
+	*) log "unknown mode: $MODE (expected standalone|proxy|parallel)"; exit 2 ;;
+esac
 
-# ---------------------------------------------------------------------------
-# 8. Confirm the virtual printer actually received the document (the job really
-#    traversed the stack, it was not just discarded by the scheduler).
-# ---------------------------------------------------------------------------
-if grep -Eqi 'job|print|document' "$IPPEVE_LOG"; then
-	log "ippeveprinter received the job"
-else
-	log "WARNING: no job activity seen in the ippeveprinter log (printed below)"
-	cat "$IPPEVE_LOG" || true
-fi
-
-log "PASS: full print-through succeeded through the snap's bundled stack"
+log "PASS: $MODE mode print-through succeeded"

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -23,6 +23,10 @@
 set -eu
 
 QUEUE="ci-everywhere"
+# NB: the snap's scripts/run-util execs the utilities via unquoted `$*`, so it
+# word-splits every argument -- no value passed to a cups.* command may contain
+# spaces.  Hence a single-token printer name here.
+PRINTER_NAME="CITestPrinter"
 PRINTER_PORT=8631
 PRINTER_URI="ipp://localhost:${PRINTER_PORT}/ipp/print"
 IPPEVE_LOG="$(mktemp)"
@@ -90,8 +94,8 @@ log "cupsd is running"
 # 4. Start a virtual IPP-Everywhere printer (bundled ippeveprinter).  We point
 #    the queue at it by explicit URI, so DNS-SD/Avahi is not required.
 # ---------------------------------------------------------------------------
-log "starting ippeveprinter on port ${PRINTER_PORT}..."
-cups.ippeveprinter -p "$PRINTER_PORT" "CI Everywhere Printer" >"$IPPEVE_LOG" 2>&1 &
+log "starting ippeveprinter '${PRINTER_NAME}' on port ${PRINTER_PORT}..."
+cups.ippeveprinter -p "$PRINTER_PORT" "$PRINTER_NAME" >"$IPPEVE_LOG" 2>&1 &
 IPPEVE_PID=$!
 
 # ---------------------------------------------------------------------------
@@ -103,8 +107,12 @@ log "creating everywhere queue '${QUEUE}' from ${PRINTER_URI}..."
 created=0
 i=0
 while [ "$i" -lt 30 ]; do
-	if kill -0 "$IPPEVE_PID" 2>/dev/null && \
-	   cups.lpadmin -p "$QUEUE" -v "$PRINTER_URI" -m everywhere -E >/dev/null 2>&1; then
+	if ! kill -0 "$IPPEVE_PID" 2>/dev/null; then
+		log "ippeveprinter exited unexpectedly; its output was:"
+		cat "$IPPEVE_LOG" 2>/dev/null || true
+		exit 1
+	fi
+	if cups.lpadmin -p "$QUEUE" -v "$PRINTER_URI" -m everywhere -E >/dev/null 2>&1; then
 		created=1; break
 	fi
 	i=$((i + 1)); sleep 1

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -264,6 +264,9 @@ run_parallel() {
 	# the host CUPS on an alternative port/socket.  Queue on the snapped cupsd.
 	install_host_cups
 	install_snap                       # starts in proxy mode initially
+	# Wait for the snap's first-run init to create cups-files.conf before we edit
+	# it (the file appears only once the snapped cupsd has started).
+	wait_scheduler "cups.lpstat"
 	mkdir -p "$(dirname "$NOPROXY_MARKER")"
 	touch "$NOPROXY_MARKER"            # force parallel (independent) mode
 	enable_filedevice "$SNAP_FILESCONF"

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -35,6 +35,9 @@ MODE="${1:?usage: sandbox-test.sh <standalone|proxy|parallel> <snap-file>}"
 SNAP_FILE="${2:?usage: sandbox-test.sh <standalone|proxy|parallel> <snap-file>}"
 
 QUEUE="ci-test"
+# Generic PostScript PPD shipped next to this script.  cups-proxyd cannot clone
+# a raw queue (it needs a PPD), so the proxy test creates the host queue with it.
+GENERIC_PPD="$(dirname "$0")/ci-generic.ppd"
 SNAP_FILESCONF="/var/snap/cups/common/etc/cups/cups-files.conf"
 HOST_FILESCONF="/etc/cups/cups-files.conf"
 NOPROXY_MARKER="/var/snap/cups/common/no-proxy"
@@ -207,8 +210,14 @@ run_proxy() {
 
 	# Create the queue on the host CUPS *before* cups-proxyd starts, so its
 	# start-up "sync with current state" (see cups-proxyd.c) mirrors an already
-	# existing queue -- rather than relying on a live notification.
-	make_raw_queue "lpadmin" "lpstat"
+	# existing queue -- rather than relying on a live notification.  Use a PPD
+	# (not a raw queue): cups-proxyd cannot clone raw queues ("Unable to load
+	# PPD ... Bad Request"), it needs the PPD to replicate the queue.
+	log "creating classic PPD queue '$QUEUE' on the host (file:/dev/null)..."
+	[ -f "$GENERIC_PPD" ] || { log "generic PPD not found: $GENERIC_PPD"; return 1; }
+	lpadmin -p "$QUEUE" -P "$GENERIC_PPD" -v file:/dev/null -E
+	lpstat -p "$QUEUE" || true
+	lpstat -v "$QUEUE" || true
 
 	install_snap                       # snap detects host CUPS -> proxy mode
 	# cups-proxyd is spawned by run-cupsd, but at first install it started before

--- a/tests/sandbox-test.sh
+++ b/tests/sandbox-test.sh
@@ -38,8 +38,6 @@ QUEUE="ci-test"
 # Generic PostScript PPD shipped next to this script.  cups-proxyd cannot clone
 # a raw queue (it needs a PPD), so the proxy test creates the host queue with it.
 GENERIC_PPD="$(dirname "$0")/ci-generic.ppd"
-SNAP_FILESCONF="/var/snap/cups/common/etc/cups/cups-files.conf"
-HOST_FILESCONF="/etc/cups/cups-files.conf"
 NOPROXY_MARKER="/var/snap/cups/common/no-proxy"
 IPPEVE_PORT=8631
 IPPEVE_NAME="CITestPrinter"
@@ -109,19 +107,10 @@ wait_scheduler() {
 	return 1
 }
 
-# Enable the "file:" backend on a CUPS instance (off by default) so the test
-# queue can use file:/dev/null without any real hardware.
-enable_filedevice() {
-	conf="$1"
-	[ -f "$conf" ] || { log "cups-files.conf not found: $conf"; return 1; }
-	grep -q '^FileDevice Yes' "$conf" 2>/dev/null || echo 'FileDevice Yes' >> "$conf"
-}
-
 install_host_cups() {
 	log "installing the host (classic) CUPS..."
 	apt-get update -y >/dev/null
 	apt-get install -y cups cups-client >/dev/null
-	enable_filedevice "$HOST_FILESCONF"
 	systemctl restart cups 2>/dev/null || service cups restart || true
 	wait_scheduler "lpstat"
 }
@@ -311,7 +300,6 @@ run_parallel() {
 	wait_scheduler "cups.lpstat"
 	mkdir -p "$(dirname "$NOPROXY_MARKER")"
 	touch "$NOPROXY_MARKER"            # force parallel (independent) mode
-	enable_filedevice "$SNAP_FILESCONF"
 	log "restarting the snapped cupsd into parallel mode..."
 	snap restart cups.cupsd
 	wait_scheduler "cups.lpstat"

--- a/tests/smoke-unpacked.sh
+++ b/tests/smoke-unpacked.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+#
+# tests/smoke-unpacked.sh <snap-file> [qemu-user-binary]
+#
+# Non-daemon smoke test for architectures where snapd cannot run inside CI
+# (the emulated armhf and riscv64 legs).  snapd needs the host kernel's
+# confinement machinery, which is not available under QEMU emulation, so we
+# cannot `snap install` and run the full daemon-level print-through there.
+#
+# Instead we unpack the built .snap and run a couple of the bundled binaries,
+# optionally through a qemu-user emulator (e.g. qemu-arm-static for armhf,
+# qemu-riscv64-static for riscv64).  This confirms the snap was produced for
+# the right architecture and its core executables are not totally broken.  It
+# is intentionally best-effort: emulated binaries can misbehave for reasons
+# unrelated to the snap, so the bundled-tool checks do not fail the job.
+#
+# The full print-through lives in tests/sandbox-test.sh and runs on the native
+# amd64/arm64 runners.
+
+set -eu
+
+SNAP_FILE="${1:?usage: smoke-unpacked.sh <snap-file> [qemu-user-binary]}"
+QEMU="${2:-}"   # empty => run the binaries natively
+
+[ -f "$SNAP_FILE" ] || { echo "smoke: snap file not found: $SNAP_FILE" >&2; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "smoke: unpacking $SNAP_FILE"
+unsquashfs -d "$WORK/squashfs-root" "$SNAP_FILE" >/dev/null
+
+ROOT="$WORK/squashfs-root"
+
+run() {
+	if [ -n "$QEMU" ]; then
+		"$QEMU" "$@"
+	else
+		"$@"
+	fi
+}
+
+# Locate a bundled binary by name across the usual snap layout dirs (the exact
+# path differs between parts, e.g. gs is bin/gs while cupsfilter is sbin/...).
+find_bin() {
+	find "$ROOT/bin" "$ROOT/sbin" "$ROOT/usr/bin" "$ROOT/usr/sbin" \
+		-maxdepth 1 -name "$1" -type f 2>/dev/null | head -1
+}
+
+# Best-effort: an emulated binary may print to stderr or exit non-zero for
+# emulation reasons; we only want to see it executes.
+GS="$(find_bin gs)"
+if [ -n "$GS" ]; then
+	echo "::group::bundled Ghostscript ($GS)"
+	run "$GS" -h || true
+	echo "::endgroup::"
+else
+	echo "smoke: WARNING: no gs binary found in the unpacked snap"
+fi
+
+CUPSFILTER="$(find_bin cupsfilter)"
+if [ -n "$CUPSFILTER" ]; then
+	echo "::group::bundled cupsfilter ($CUPSFILTER)"
+	run "$CUPSFILTER" --help 2>&1 || true
+	echo "::endgroup::"
+fi
+
+echo "smoke: unpacked-binary smoke test finished for $SNAP_FILE${QEMU:+ (via $QEMU)}"

--- a/tests/smoke-unpacked.sh
+++ b/tests/smoke-unpacked.sh
@@ -2,67 +2,106 @@
 #
 # tests/smoke-unpacked.sh <snap-file> [qemu-user-binary]
 #
-# Non-daemon smoke test for architectures where snapd cannot run inside CI
-# (the emulated armhf and riscv64 legs).  snapd needs the host kernel's
-# confinement machinery, which is not available under QEMU emulation, so we
-# cannot `snap install` and run the full daemon-level print-through there.
+# Non-daemon verification for the architectures where the full print-through
+# cannot run inside CI: the emulated armhf and riscv64 legs.  Two things block
+# the daemon-level test there:
+#   1. snapd needs the host kernel's confinement machinery, unavailable under
+#      QEMU emulation, so we cannot `snap install` and run the bundled cupsd.
+#   2. The snap's executables are dynamically linked against the base-snap
+#      (core22) runtime, which is not inside the .snap, so they cannot even be
+#      run reliably under qemu-user (the loader/libs are missing) -- attempts
+#      just fail with "Could not open .../ld-linux-*.so".
 #
-# Instead we unpack the built .snap and run a couple of the bundled binaries,
-# optionally through a qemu-user emulator (e.g. qemu-arm-static for armhf,
-# qemu-riscv64-static for riscv64).  This confirms the snap was produced for
-# the right architecture and its core executables are not totally broken.  It
-# is intentionally best-effort: emulated binaries can misbehave for reasons
-# unrelated to the snap, so the bundled-tool checks do not fail the job.
+# So instead of pretending to "run" them (which silently no-ops), we verify the
+# artifact STATICALLY: the snap unpacks, the key executables are present, and
+# they are ELF binaries of the expected cross-architecture.  That reliably
+# catches a build that produced the wrong architecture or is missing core
+# components -- which is the real risk for an emulated build.
 #
-# The full print-through lives in tests/sandbox-test.sh and runs on the native
-# amd64/arm64 runners.
+# The full daemon-level print-through lives in tests/sandbox-test.sh and runs on
+# the native amd64/arm64 runners.
 
 set -eu
 
 SNAP_FILE="${1:?usage: smoke-unpacked.sh <snap-file> [qemu-user-binary]}"
-QEMU="${2:-}"   # empty => run the binaries natively
+QEMU="${2:-}"   # used only to derive the expected arch + a best-effort run
 
 [ -f "$SNAP_FILE" ] || { echo "smoke: snap file not found: $SNAP_FILE" >&2; exit 1; }
+
+# Expected architecture token in file(1) output, derived from the qemu-user name.
+case "$QEMU" in
+	*riscv64*)        ARCH_TOKEN="RISC-V" ;;
+	*aarch64*|*arm64*) ARCH_TOKEN="aarch64" ;;
+	*arm*)            ARCH_TOKEN="ARM" ;;
+	*)                ARCH_TOKEN="" ;;   # native / unknown: don't assert a token
+esac
 
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 
 echo "smoke: unpacking $SNAP_FILE"
 unsquashfs -d "$WORK/squashfs-root" "$SNAP_FILE" >/dev/null
-
 ROOT="$WORK/squashfs-root"
 
-run() {
-	if [ -n "$QEMU" ]; then
-		"$QEMU" "$@"
-	else
-		"$@"
-	fi
-}
-
 # Locate a bundled binary by name across the usual snap layout dirs (the exact
-# path differs between parts, e.g. gs is bin/gs while cupsfilter is sbin/...).
+# path differs between parts, e.g. gs is bin/gs while cupsd is sbin/cupsd).
 find_bin() {
 	find "$ROOT/bin" "$ROOT/sbin" "$ROOT/usr/bin" "$ROOT/usr/sbin" \
 		-maxdepth 1 -name "$1" -type f 2>/dev/null | head -1
 }
 
-# Best-effort: an emulated binary may print to stderr or exit non-zero for
-# emulation reasons; we only want to see it executes.
-GS="$(find_bin gs)"
-if [ -n "$GS" ]; then
-	echo "::group::bundled Ghostscript ($GS)"
-	run "$GS" -h || true
-	echo "::endgroup::"
-else
-	echo "smoke: WARNING: no gs binary found in the unpacked snap"
+# Verify a bundled binary exists and is an ELF of the expected architecture.
+# Fails the job on a missing binary, a non-ELF, or a wrong-architecture build.
+check_bin() {
+	name="$1"; required="$2"
+	path="$(find_bin "$name")"
+	if [ -z "$path" ]; then
+		if [ "$required" = required ]; then
+			echo "smoke: ERROR: required binary '$name' not found in the snap" >&2
+			exit 1
+		fi
+		echo "smoke: note: optional binary '$name' not present"
+		return 0
+	fi
+
+	desc="$(file -b "$path")"
+	echo "smoke: $name -> $desc"
+
+	case "$desc" in
+		*ELF*) : ;;
+		*) echo "smoke: ERROR: '$name' is not an ELF executable" >&2; exit 1 ;;
+	esac
+
+	# These are cross-architecture legs, so the bundled binary must NOT be the
+	# x86-64 host architecture.
+	case "$desc" in
+		*x86-64*) echo "smoke: ERROR: '$name' is x86-64, expected a cross build" >&2; exit 1 ;;
+	esac
+
+	if [ -n "$ARCH_TOKEN" ]; then
+		case "$desc" in
+			*"$ARCH_TOKEN"*) : ;;
+			*) echo "smoke: ERROR: '$name' is not $ARCH_TOKEN as expected" >&2; exit 1 ;;
+		esac
+	fi
+}
+
+echo "::group::architecture verification${ARCH_TOKEN:+ (expecting $ARCH_TOKEN)}"
+check_bin gs        required    # bundled Ghostscript
+check_bin cupsd     required    # the CUPS scheduler
+check_bin cupsfilter optional   # a representative filter-chain entry point
+echo "::endgroup::"
+
+# Best-effort, informational only: if a matching userspace happens to be present
+# the binary may run; we never fail the job on this (the loader is normally
+# absent under qemu-user for a snap's binaries).
+if [ -n "$QEMU" ] && command -v "$QEMU" >/dev/null 2>&1; then
+	GS="$(find_bin gs)"
+	if [ -n "$GS" ]; then
+		echo "::group::best-effort: $QEMU gs -h"
+		"$QEMU" "$GS" -h 2>&1 | head -5 || true
+		echo "::endgroup::"
+	fi
 fi
 
-CUPSFILTER="$(find_bin cupsfilter)"
-if [ -n "$CUPSFILTER" ]; then
-	echo "::group::bundled cupsfilter ($CUPSFILTER)"
-	run "$CUPSFILTER" --help 2>&1 || true
-	echo "::endgroup::"
-fi
-
-echo "smoke: unpacked-binary smoke test finished for $SNAP_FILE${QEMU:+ (via $QEMU)}"
+echo "smoke: verification passed for $SNAP_FILE${QEMU:+ ($ARCH_TOKEN)}"


### PR DESCRIPTION
## Summary

  The CUPS Snap currently builds in CI but is only smoke-checked (`snap run cups.gs -h`).This PR adds real integration testing of the snap in **all three modes its `run-cupsd` selects between**, plus per-architecture coverage:

  - **stand-alone** — no system CUPS; the snap's cupsd is the system CUPS.
  - **proxy** — a classic system CUPS is present (no `no-proxy` marker); the snap
    runs `cups-proxyd` and proxies snapped clients' jobs to the host CUPS.
  - **parallel** — system CUPS present **and** the `no-proxy` marker; the snap's cupsd runs independently on its own port/socket.

  A Snap bundles its whole printing stack at pinned versions, so the multi-CUPS build matrix used by the Autotools repos does not apply here — what matters is that the snapped cupsd behaves correctly in each mode.

  ## What is tested

  **Native (amd64, arm64) — full daemon-level print-through, one job per mode:**
  - *stand-alone:* a driverless queue is created on the snapped cupsd (via the bundled `ippeveprinter`, safe here since there is a single CUPS instance), a job is printed and verified to reach `completed`.
  - *proxy:* the queue is created on the **host** CUPS the classic way; the snap's `cups-proxyd` mirrors it into the snapped CUPS, a job from the **snapped** `lp` is proxied to the host and verified to complete there.
  - *parallel:* the snap is forced independent (`no-proxy` marker), and a queue + job are created/verified on the snapped cupsd.

  **Emulated (armhf, riscv64) — non-daemon verification:** snapd cannot run under QEMU and the snap's binaries are linked against the core22 base (not bundled), so instead of pretending to run them, the built snap is unpacked and its key binaries (`gs`, `cupsd`, `cupsfilter`) are verified to be ELF executables of the correct architecture. armhf is built via Launchpad; riscv64 is pulled from the Snap Store edge channel on a daily schedule.

  ## Design notes

  - **No `ippeveprinter` where multiple CUPS instances exist.** Its DNS-SD queue would be advertised to *all* instances, so proxy/parallel create queues the classic way (`lpadmin`).
  - **Proxy needs a PPD.** `cups-proxyd` cannot clone a raw queue (`Unable to load PPD ... Bad Request`), so the proxy host queue is created with a small generic PostScript PPD shipped in `tests/`.
  - Everything per-mode lives in `tests/sandbox-test.sh <mode>`; the workflow builds the snap once per arch and each (arch, mode) test runs in its own job.

  ## Changes

  - `tests/sandbox-test.sh` — mode-aware native print-through test.
  - `tests/smoke-unpacked.sh` — emulated-arch ELF verification helper.
  - `tests/ci-generic.ppd` — generic PostScript PPD for the proxy queue.
  - `.github/workflows/build.yml` — build-once-per-arch + a 6-job test matrix (2 arch × 3 modes); armhf build + smoke.
  - `.github/workflows/test-riscv-edge.yml` — riscv64 edge smoke via the shared helper.
  - `.github/workflows/{build,cppcheck,static-analysis}.yml` — run on all branches.

  ## Test results

  | Architecture | Case | Test performed | Result |
  |---|---|---|---|
  | amd64 (native) | stand-alone | Driverless print-through on the snapped cupsd | ✅ pass |
  | amd64 (native) | proxy | Host queue → mirrored by cups-proxyd → snapped job proxied to host | ✅ pass |
  | amd64 (native) | parallel | Print-through on the independent snapped cupsd | ✅ pass |
  | arm64 (native) | stand-alone | Driverless print-through on the snapped cupsd | ✅ pass |
  | arm64 (native) | proxy | Host queue → mirrored by cups-proxyd → snapped job proxied to host | ✅ pass |
  | arm64 (native) | parallel | Print-through on the independent snapped cupsd | ✅ pass |
  | armhf (emulated) | build + verify | Launchpad build; unpack + verify ARM ELF binaries | ✅ pass |
  | riscv64 (emulated) | build + verify | Snap Store edge build; unpack + verify RISC-V ELF binaries | ✅pass |