### PR TITLE
Harden riscv edge snap download against store CDN flakes

### DIFF
--- a/.github/workflows/test-riscv-edge.yml
+++ b/.github/workflows/test-riscv-edge.yml
@@ -41,7 +41,14 @@ jobs:
         if: steps.snap-info.outputs.available == 'true'
         run: |
           echo "Downloading from: ${{ steps.snap-info.outputs.url }}"
-          curl -L "${{ steps.snap-info.outputs.url }}" -o cups_riscv64.snap
+          # The Snap Store CDN occasionally throttles or drops the transfer
+          # mid-stream (seen as "curl: (92) HTTP/2 stream ... CANCEL"), which is
+          # transient store-side infra, not a snap problem.  Force HTTP/1.1 to
+          # avoid the HTTP/2 stream-cancel mode, retry on any error, and resume
+          # the partial download instead of restarting from zero.
+          curl -L --http1.1 --retry 5 --retry-all-errors --retry-delay 10 \
+               -C - --connect-timeout 30 \
+               "${{ steps.snap-info.outputs.url }}" -o cups_riscv64.snap
           echo "Download complete."
 
       - name: Install QEMU Emulator & Unpack Tools


### PR DESCRIPTION
The daily **RISC-V Edge Snap Tester** failed on 2026-07-09 (green every prior day) on both this repo and my fork. The job never reached the smoke test — it failed at the *Download the Snap* step: the Snap Store CDN throttled the transfer to ~20 KB/s and dropped it at ~51%:

```
curl: (92) HTTP/2 stream 1 was not closed cleanly: CANCEL (err 8)
##[error]Process completed with exit code 92.
```

That's a transient store-side/network flake (it hit upstream and the fork in the same window), not the snap or the test logic.

This hardens the one `curl` that pulls the edge snap so it rides out such flakes:

- `--http1.1` — sidesteps the HTTP/2 stream-cancel mode entirely (exit 92).
- `--retry 5 --retry-all-errors --retry-delay 10` — retries mid-stream drops (plain `--retry` won't catch a stream cancel).
- `-C -` — resumes the partial download instead of restarting from zero.
- `--connect-timeout 30` — fails fast on a dead connect.

One-line change to `test-riscv-edge.yml`; no test logic touched. (The armhf leg builds on Launchpad rather than downloading, so nothing to mirror there.)